### PR TITLE
[Feat/#6] create: Redis 사용을 위한 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,18 +18,34 @@ configurations {
 }
 
 repositories {
+	dependencies {
+		// SpringBoot
+		implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+		implementation 'org.springframework.boot:spring-boot-starter-web'
+
+		// Test
+		testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+		// Lombok
+		compileOnly 'org.projectlombok:lombok'
+		annotationProcessor 'org.projectlombok:lombok'
+
+		// H2
+		runtimeOnly 'com.h2database:h2'
+
+		// Redis
+		implementation group: 'org.springframework.boot', name: 'spring-boot-starter-data-redis', version: '3.2.4'
+
+		// Jackson
+		implementation 'com.fasterxml.jackson.core:jackson-core:2.16.1'
+	}
 	mavenCentral()
 }
 
 dependencies {
-	implementation 'com.fasterxml.jackson.core:jackson-core:2.16.1'
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.h2database:h2'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.projectlombok:lombok:1.18.22'
 }
+
 
 tasks.named('test') {
 	useJUnitPlatform()

--- a/src/main/java/zzandori/zzanmoa/redis/config/RedisConfig.java
+++ b/src/main/java/zzandori/zzanmoa/redis/config/RedisConfig.java
@@ -1,0 +1,33 @@
+package zzandori.zzanmoa.redis.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@RequiredArgsConstructor
+@Configuration
+@EnableRedisRepositories
+public class RedisConfig {
+    private final RedisProperties redisProperties;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(redisProperties.getHost(), redisProperties.getPort());
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+        return redisTemplate;
+    }
+}

--- a/src/main/java/zzandori/zzanmoa/redis/service/RedisService.java
+++ b/src/main/java/zzandori/zzanmoa/redis/service/RedisService.java
@@ -1,0 +1,66 @@
+package zzandori.zzanmoa.redis.service;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RedisService {
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    public void setValues(String key, String data) {
+        ValueOperations<String, Object> values = redisTemplate.opsForValue();
+        values.set(key, data);
+    }
+
+    public void setValues(String key, String data, Duration duration) {
+        ValueOperations<String, Object> values = redisTemplate.opsForValue();
+        values.set(key, data, duration);
+    }
+
+    @Transactional(readOnly = true)
+    public String getValues(String key) {
+        ValueOperations<String, Object> values = redisTemplate.opsForValue();
+        if (values.get(key) == null) {
+            return "false";
+        }
+        return (String) values.get(key);
+    }
+
+    public void deleteValues(String key) {
+        redisTemplate.delete(key);
+    }
+
+    public void expireValues(String key, int timeout) {
+        redisTemplate.expire(key, timeout, TimeUnit.MILLISECONDS);
+    }
+
+    public void setHashOps(String key, Map<String, String> data) {
+        HashOperations<String, Object, Object> values = redisTemplate.opsForHash();
+        values.putAll(key, data);
+    }
+
+    @Transactional(readOnly = true)
+    public String getHashOps(String key, String hashKey) {
+        HashOperations<String, Object, Object> values = redisTemplate.opsForHash();
+        return Boolean.TRUE.equals(values.hasKey(key, hashKey)) ? (String) redisTemplate.opsForHash().get(key, hashKey) : "";
+    }
+
+    public void deleteHashOps(String key, String hashKey) {
+        HashOperations<String, Object, Object> values = redisTemplate.opsForHash();
+        values.delete(key, hashKey);
+    }
+
+    public boolean checkExistsValue(String value) {
+        return !value.equals("false");
+    }
+}

--- a/src/test/java/zzandori/zzanmoa/redis/service/RedisServiceTest.java
+++ b/src/test/java/zzandori/zzanmoa/redis/service/RedisServiceTest.java
@@ -1,0 +1,115 @@
+package zzandori.zzanmoa.redis.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.time.Duration;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@Slf4j
+@SpringBootTest
+class RedisServiceTest {
+
+    final String KEY = "key";
+    final String VALUE = "value";
+
+    @Autowired
+    private RedisService redisService;
+
+    @AfterEach
+    void tearDown() {
+        redisService.deleteValues(KEY);
+    }
+
+    @Test
+    @DisplayName("Redis에 데이터를 저장하면 정상적으로 조회된다.")
+    void saveAndFind() {
+        // given
+        redisService.setValues(KEY, VALUE);
+
+        // when
+        String findValue = redisService.getValues(KEY);
+
+        // then
+        assertThat(findValue).isEqualTo(VALUE);
+    }
+
+    @Test
+    @DisplayName("Redis에 저장된 데이터를 수정할 수 있다.")
+    void update() {
+        // given
+        redisService.setValues(KEY, VALUE);
+
+        String updateValue = "updateValue";
+        redisService.setValues(KEY, updateValue);
+
+        // when
+        String findValue = redisService.getValues(KEY);
+
+        // then
+        assertThat(updateValue).isEqualTo(findValue);
+        assertThat(VALUE).isNotEqualTo(findValue);
+    }
+
+    @Test
+    @DisplayName("Redis에 저장된 데이터를 삭제할 수 있다.")
+    void delete() {
+        // given
+        redisService.setValues(KEY, VALUE);
+
+        // when
+        redisService.deleteValues(KEY);
+        String findValue = redisService.getValues(KEY);
+
+        // then
+        assertThat(findValue).isEqualTo("false");
+    }
+
+    @Test
+    @DisplayName("Redis에 만료시간과 함께 데이터를 저장할 수 있고 만료시간이 지나면 삭제된다.")
+    void saveWithDurationAndExpired() {
+        // given
+        Duration DURATION = Duration.ofMillis(5000);
+
+        // when
+        redisService.setValues(KEY, VALUE, DURATION);
+        String findValue = redisService.getValues(KEY);
+
+        // then
+        await().pollDelay(Duration.ofMillis(6000)).untilAsserted(
+            () -> {
+                String expiredValue = redisService.getValues(KEY);
+                assertThat(expiredValue).isNotEqualTo(findValue);
+                assertThat(expiredValue).isEqualTo("false");
+            }
+        );
+    }
+
+    @DisplayName("Redis에 저장된 데이터에 만료시간을 설정할 수 있고 만료시간이 지나면 삭제된다.")
+    @Test
+    void setDurationAfterSaveAndExpired() {
+        // given
+        redisService.setValues(KEY, VALUE);
+
+        // when
+        int timeout = 5000;
+        redisService.expireValues(KEY, timeout);
+
+        String findValue = redisService.getValues(KEY);
+
+        // then
+        await().pollDelay(Duration.ofMillis(6000)).untilAsserted(
+            () -> {
+                String expiredValue = redisService.getValues(KEY);
+                assertThat(expiredValue).isNotEqualTo(findValue);
+                assertThat(expiredValue).isEqualTo("false");
+            }
+        );
+    }
+
+}


### PR DESCRIPTION
자동완성 기능을 구현하기 위한 Redis 설정이 필요하다.

**✔️ Redis를 선택한 이유**
- QueryDSL을 사용하여 구현할 수 있으나, 완전히 똑같은 검색어만 검색이 된다는 문제점이 있다.
- SQL의 Like 문을 사용하여 구현할 수 있으나, table full scan 방식을 사용하고 이는 굉장히 비효율적이라고 한다.
- ElasticSearch를 사용하여 구현할 수 있으나, 아래 이유로 선택을 하지 않았다.
    - 대규모 데이터를 다루지 않는다는 점
    - 초기설정과 유지 관리에 많은 시간과 비용이 소요된다는 점

소규모 프로젝트로 개발 기간이 짧고, 비용 절감이 중요하기 때문에 Redis를 사용하는 것이 적절하다고 판단하였다.

**🚀 구현 목록**
- RedisConfig : Redis 사용을 위한 설정 파일
- RedisService : Redis를 사용하기 위한 기능
- RedisServiceTest : Redis를 사용하기 위한 기능 테스트