### PR TITLE
[Feat/#5] create: 서울시 시장 리스트 응답 기능 구현

### DIFF
--- a/src/main/java/zzandori/zzanmoa/market/controller/MarketController.java
+++ b/src/main/java/zzandori/zzanmoa/market/controller/MarketController.java
@@ -1,0 +1,22 @@
+package zzandori.zzanmoa.market.controller;
+
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import zzandori.zzanmoa.market.dto.MarketResponseDto;
+import zzandori.zzanmoa.market.service.MarketService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/market")
+public class MarketController {
+
+    private final MarketService marketService;
+
+    @GetMapping("/get")
+    public MarketResponseDto getMarkets() throws IOException {
+        return marketService.getMarkets();
+    }
+}

--- a/src/main/java/zzandori/zzanmoa/market/dto/MarketResponseDto.java
+++ b/src/main/java/zzandori/zzanmoa/market/dto/MarketResponseDto.java
@@ -1,0 +1,23 @@
+package zzandori.zzanmoa.market.dto;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import lombok.ToString;
+
+
+@ToString
+public class MarketResponseDto {
+
+    private Map<String, Set<String>> marketMap;
+
+    public MarketResponseDto() {
+        this.marketMap = new HashMap<>();
+    }
+
+    public void addMarket(String district, String marketName) {
+        this.marketMap.computeIfAbsent(district, k -> new HashSet<>()).add(marketName);
+    }
+
+}

--- a/src/main/java/zzandori/zzanmoa/market/dto/MarketResponseDto.java
+++ b/src/main/java/zzandori/zzanmoa/market/dto/MarketResponseDto.java
@@ -4,9 +4,10 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import lombok.Getter;
 import lombok.ToString;
 
-
+@Getter
 @ToString
 public class MarketResponseDto {
 

--- a/src/main/java/zzandori/zzanmoa/market/service/MarketService.java
+++ b/src/main/java/zzandori/zzanmoa/market/service/MarketService.java
@@ -1,0 +1,48 @@
+package zzandori.zzanmoa.market.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import zzandori.zzanmoa.market.dto.MarketResponseDto;
+import zzandori.zzanmoa.openapi.service.OpenAPIService;
+
+@RequiredArgsConstructor
+@Service
+public class MarketService {
+
+    private final OpenAPIService openApiService;
+
+    public MarketResponseDto getMarkets() throws IOException {
+
+        return connectOpenAPI();
+    }
+
+    private MarketResponseDto connectOpenAPI() throws IOException {
+        StringBuilder sb = openApiService.initRequest("ListNecessariesPricesService", "1", "1000");
+        return convertToDto(openApiService.connectOpenAPI(sb));
+    }
+
+    private MarketResponseDto convertToDto(String json) throws IOException {
+
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode rootNode = mapper.readTree(json);
+        JsonNode rows = rootNode.path("ListNecessariesPricesService").path("row");
+
+        MarketResponseDto marketResponseDto = new MarketResponseDto();
+
+        if (rows.isArray()) {
+            for (JsonNode row : rows) {
+                System.out.println(row);
+                String marketName = row.get("M_NAME").asText();
+                String district = row.get("M_GU_NAME").asText();
+                marketResponseDto.addMarket(district, marketName);
+            }
+        }
+
+        return marketResponseDto;
+    }
+
+
+}


### PR DESCRIPTION
## 서울시 시장 리스트 응답 기능
1. Open API 요청 후, 시장 데이터 받기
2. 시장 이름, 자치구 데이터만 추출
3. Map<String, Set<String>> 형태의 DTO로 응답