### PR TITLE
[Feat/#17] 알뜰 가게 정보 응답 및 관련 DB 재설계

### DIFF
--- a/src/main/java/zzandori/zzanmoa/thriftstore/controller/ThriftStoreController.java
+++ b/src/main/java/zzandori/zzanmoa/thriftstore/controller/ThriftStoreController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import zzandori.zzanmoa.thriftstore.dto.CategoryPriceDTO;
+import zzandori.zzanmoa.thriftstore.dto.StoreInfoDTO;
 import zzandori.zzanmoa.thriftstore.service.ThriftStoreService;
 
 @RestController
@@ -18,11 +19,14 @@ public class ThriftStoreController {
     private final ThriftStoreService thriftStoreService;
 
 
-
-    @GetMapping("/get")
-    public List<CategoryPriceDTO> getStores(){
-
+    @GetMapping("/get/category")
+    public List<CategoryPriceDTO> getCategoryPrice(){
         return thriftStoreService.getCategoryPrice();
+    }
+
+    @GetMapping("get/store")
+    public List<StoreInfoDTO> getStores(){
+        return thriftStoreService.getAllStoresWithItems();
     }
 
 

--- a/src/main/java/zzandori/zzanmoa/thriftstore/controller/ThriftStoreController.java
+++ b/src/main/java/zzandori/zzanmoa/thriftstore/controller/ThriftStoreController.java
@@ -1,11 +1,13 @@
 package zzandori.zzanmoa.thriftstore.controller;
 
 import java.io.IOException;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import zzandori.zzanmoa.thriftstore.dto.CategoryPriceDTO;
 import zzandori.zzanmoa.thriftstore.service.ThriftStoreService;
 
 @RestController
@@ -14,6 +16,15 @@ import zzandori.zzanmoa.thriftstore.service.ThriftStoreService;
 public class ThriftStoreController {
 
     private final ThriftStoreService thriftStoreService;
+
+
+
+    @GetMapping("/get")
+    public List<CategoryPriceDTO> getStores(){
+
+        return thriftStoreService.getCategoryPrice();
+    }
+
 
     @GetMapping("/connectAPI/{startIndex}/{endIndex}")
     public void connectOpenAPI(@PathVariable("startIndex") String startIndex,

--- a/src/main/java/zzandori/zzanmoa/thriftstore/dto/CategoryPriceDTO.java
+++ b/src/main/java/zzandori/zzanmoa/thriftstore/dto/CategoryPriceDTO.java
@@ -1,0 +1,15 @@
+package zzandori.zzanmoa.thriftstore.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
+@AllArgsConstructor
+@Getter
+@ToString
+public class CategoryPriceDTO {
+    private String category;
+    private Integer minPrice;
+    private Integer maxPrice;
+
+}

--- a/src/main/java/zzandori/zzanmoa/thriftstore/dto/ItemInfoDTO.java
+++ b/src/main/java/zzandori/zzanmoa/thriftstore/dto/ItemInfoDTO.java
@@ -1,0 +1,19 @@
+package zzandori.zzanmoa.thriftstore.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class ItemInfoDTO {
+    private String itemId;
+    private String item;
+    private String category;
+    private Integer price;
+}

--- a/src/main/java/zzandori/zzanmoa/thriftstore/dto/StoreInfoDTO.java
+++ b/src/main/java/zzandori/zzanmoa/thriftstore/dto/StoreInfoDTO.java
@@ -1,0 +1,25 @@
+package zzandori.zzanmoa.thriftstore.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+import lombok.ToString;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString
+public class StoreInfoDTO {
+    private String storeId;
+    private String storeName;
+    private String phoneNumber;
+    private String address;
+    private List<ItemInfoDTO> items;
+
+}

--- a/src/main/java/zzandori/zzanmoa/thriftstore/dto/StoreWithItemDTO.java
+++ b/src/main/java/zzandori/zzanmoa/thriftstore/dto/StoreWithItemDTO.java
@@ -1,0 +1,22 @@
+package zzandori.zzanmoa.thriftstore.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class StoreWithItemDTO {
+
+    private String storeId;
+    private String storeName;
+    private String category;
+    private String itemId;
+    private String phoneNumber;
+    private String address;
+}

--- a/src/main/java/zzandori/zzanmoa/thriftstore/entity/SavingItem.java
+++ b/src/main/java/zzandori/zzanmoa/thriftstore/entity/SavingItem.java
@@ -1,0 +1,44 @@
+package zzandori.zzanmoa.thriftstore.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Entity
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+@Table(name = "saving_item")
+public class SavingItem {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @Column(name = "item_id")
+    private String itemId;
+
+    @Column(name = "item_name")
+    private String itemName;
+
+    @Column(name = "category")
+    private String category;
+
+    @Column(name = "price")
+    private Integer price;
+
+    @ManyToOne
+    @JoinColumn(name = "store_id", referencedColumnName = "store_id")
+    private SavingStore store;
+}

--- a/src/main/java/zzandori/zzanmoa/thriftstore/entity/SavingStore.java
+++ b/src/main/java/zzandori/zzanmoa/thriftstore/entity/SavingStore.java
@@ -1,0 +1,44 @@
+package zzandori.zzanmoa.thriftstore.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Entity
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+@Table(name = "saving_store")
+public class SavingStore {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @Column(name = "store_id")
+    private String storeId;
+
+    @Column(name = "store_name")
+    private String storeName;
+
+    @Column(name = "phone_number")
+    private String phoneNumber;
+
+    @Column(name = "address")
+    private String address;
+
+    @OneToMany(mappedBy = "store", fetch = FetchType.LAZY)
+    private List<SavingItem> items;
+}

--- a/src/main/java/zzandori/zzanmoa/thriftstore/repository/SavingItemRepository.java
+++ b/src/main/java/zzandori/zzanmoa/thriftstore/repository/SavingItemRepository.java
@@ -1,0 +1,16 @@
+package zzandori.zzanmoa.thriftstore.repository;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import zzandori.zzanmoa.thriftstore.dto.CategoryPriceDTO;
+import zzandori.zzanmoa.thriftstore.entity.SavingItem;
+
+public interface SavingItemRepository extends JpaRepository<SavingItem, Long> {
+
+    @Query("SELECT new zzandori.zzanmoa.thriftstore.dto.CategoryPriceDTO(i.category, MIN(i.price), MAX(i.price)) " +
+        "FROM SavingItem i WHERE i.price > 0 " +
+        "GROUP BY i.category")
+    List<CategoryPriceDTO> findCategoryPrices();
+
+}

--- a/src/main/java/zzandori/zzanmoa/thriftstore/repository/SavingStoreRepository.java
+++ b/src/main/java/zzandori/zzanmoa/thriftstore/repository/SavingStoreRepository.java
@@ -1,0 +1,12 @@
+package zzandori.zzanmoa.thriftstore.repository;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import zzandori.zzanmoa.thriftstore.entity.SavingStore;
+
+public interface SavingStoreRepository extends JpaRepository<SavingStore, Long> {
+
+    @Query("SELECT s FROM SavingStore s JOIN FETCH s.items")
+    List<SavingStore> findAllStoreWithItems();
+}

--- a/src/main/java/zzandori/zzanmoa/thriftstore/repository/ThriftStoreRepository.java
+++ b/src/main/java/zzandori/zzanmoa/thriftstore/repository/ThriftStoreRepository.java
@@ -1,20 +1,11 @@
 package zzandori.zzanmoa.thriftstore.repository;
 
-import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import zzandori.zzanmoa.thriftstore.dto.CategoryPriceDTO;
 import zzandori.zzanmoa.thriftstore.entity.ThriftStore;
 
 public interface ThriftStoreRepository extends JpaRepository<ThriftStore, Long> {
 
     Optional<ThriftStore> findByStoreIdAndItemId(String storeId, String itemId);
-
-
-    @Query("SELECT new zzandori.zzanmoa.thriftstore.dto.CategoryPriceDTO(t.category, MIN(t.price), MAX(t.price)) " +
-        "FROM ThriftStore t WHERE t.price > 0 " +
-        "GROUP BY t.category")
-    List<CategoryPriceDTO> findCategoryPrices();
 
 }

--- a/src/main/java/zzandori/zzanmoa/thriftstore/repository/ThriftStoreRepository.java
+++ b/src/main/java/zzandori/zzanmoa/thriftstore/repository/ThriftStoreRepository.java
@@ -1,12 +1,20 @@
 package zzandori.zzanmoa.thriftstore.repository;
 
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import zzandori.zzanmoa.thriftstore.dto.CategoryPriceDTO;
 import zzandori.zzanmoa.thriftstore.entity.ThriftStore;
 
 public interface ThriftStoreRepository extends JpaRepository<ThriftStore, Long> {
 
     Optional<ThriftStore> findByStoreIdAndItemId(String storeId, String itemId);
 
+
+    @Query("SELECT new zzandori.zzanmoa.thriftstore.dto.CategoryPriceDTO(t.category, MIN(t.price), MAX(t.price)) " +
+        "FROM ThriftStore t WHERE t.price > 0 " +
+        "GROUP BY t.category")
+    List<CategoryPriceDTO> findCategoryPrices();
 
 }

--- a/src/main/java/zzandori/zzanmoa/thriftstore/service/ThriftStoreService.java
+++ b/src/main/java/zzandori/zzanmoa/thriftstore/service/ThriftStoreService.java
@@ -3,8 +3,11 @@ package zzandori.zzanmoa.thriftstore.service;
 import java.io.IOException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import zzandori.zzanmoa.openapi.service.OpenAPIService;
+import zzandori.zzanmoa.thriftstore.dto.CategoryPriceDTO;
 import zzandori.zzanmoa.thriftstore.entity.ThriftStore;
 import zzandori.zzanmoa.thriftstore.repository.ThriftStoreRepository;
 
@@ -15,6 +18,14 @@ public class ThriftStoreService {
     private final OpenAPIService openApiService;
     private final ThriftDataProcessor thriftDataProcessor;
     private final ThriftStoreRepository thriftStoreRepository;
+    private static final Logger logger = LoggerFactory.getLogger(ThriftStoreService.class);
+
+
+    public List<CategoryPriceDTO> getCategoryPrice(){
+        List<CategoryPriceDTO> results = thriftStoreRepository.findCategoryPrices();
+        logger.info("Fetched category prices size: {}", results.size());
+        return results;
+    }
 
     public String connectOpenAPI(String startIndex, String endIndex) throws IOException {
         StringBuilder sb = openApiService.initRequest("IndividualServiceChargeService", startIndex,

--- a/src/main/java/zzandori/zzanmoa/thriftstore/service/ThriftStoreService.java
+++ b/src/main/java/zzandori/zzanmoa/thriftstore/service/ThriftStoreService.java
@@ -2,13 +2,18 @@ package zzandori.zzanmoa.thriftstore.service;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import zzandori.zzanmoa.openapi.service.OpenAPIService;
 import zzandori.zzanmoa.thriftstore.dto.CategoryPriceDTO;
+import zzandori.zzanmoa.thriftstore.dto.ItemInfoDTO;
+import zzandori.zzanmoa.thriftstore.dto.StoreInfoDTO;
 import zzandori.zzanmoa.thriftstore.entity.ThriftStore;
+import zzandori.zzanmoa.thriftstore.repository.SavingItemRepository;
+import zzandori.zzanmoa.thriftstore.repository.SavingStoreRepository;
 import zzandori.zzanmoa.thriftstore.repository.ThriftStoreRepository;
 
 @RequiredArgsConstructor
@@ -18,14 +23,32 @@ public class ThriftStoreService {
     private final OpenAPIService openApiService;
     private final ThriftDataProcessor thriftDataProcessor;
     private final ThriftStoreRepository thriftStoreRepository;
+    private final SavingStoreRepository savingStoreRepository;
+    private final SavingItemRepository savingItemRepository;
+
     private static final Logger logger = LoggerFactory.getLogger(ThriftStoreService.class);
 
 
     public List<CategoryPriceDTO> getCategoryPrice(){
-        List<CategoryPriceDTO> results = thriftStoreRepository.findCategoryPrices();
+        List<CategoryPriceDTO> results = savingItemRepository.findCategoryPrices();
         logger.info("Fetched category prices size: {}", results.size());
         return results;
     }
+
+    public List<StoreInfoDTO> getAllStoresWithItems() {
+        return savingStoreRepository.findAllStoreWithItems().stream()
+            .map(store -> new StoreInfoDTO(
+                store.getStoreId(),
+                store.getStoreName(),
+                store.getPhoneNumber(),
+                store.getAddress(),
+                store.getItems().stream()
+                    .map(item -> new ItemInfoDTO(item.getItemId(), item.getItemName(), item.getCategory(), item.getPrice()))
+                    .collect(Collectors.toList())))
+            .collect(Collectors.toList());
+    }
+
+
 
     public String connectOpenAPI(String startIndex, String endIndex) throws IOException {
         StringBuilder sb = openApiService.initRequest("IndividualServiceChargeService", startIndex,


### PR DESCRIPTION
### **1. 테이블 분리 이유**

- **성능 개선**: **`thrift_store`** 테이블에서 자기 자신과의 조인을 수행하는 것은 성능 저하를 일으킬 수 있습니다. 특히 테이블이 커지면 자기 조인의 비용이 증가합니다.
- **데이터 정규화**: 테이블을 분리함으로써 데이터 정규화를 달성하여 데이터 중복을 줄이고, 데이터 무결성을 향상시킬 수 있습니다.
- **관리 용이성**: 가게 정보와 품목 정보를 분리함으로써 각각에 대한 관리와 확장이 용이해집니다.

### **2. 테이블 구조**

- **`saving_store`**: 가게에 대한 정보를 저장합니다.
    - **`id`**: 가게의 고유 식별자 (기본 키)
    - **`store_id`**: 가게의 외부 식별 코드
    - **`store_name`**: 가게 이름
    - **`phone_number`**: 전화번호
    - **`address`**: 주소
   

- **`saving_item`**: 각 가게의 품목 정보를 저장합니다.
    - **`id`**: 품목의 고유 식별자 (기본 키)
    - **`item_id`**: 품목의 외부 식별 코드
    - **`item_name`**: 품목 이름
    - **`category`**: 품목 카테고리
    - **`price`**: 가격
    - **`store_id`**: 연관된 가게의 외부 식별 코드 (`saving_store`의 `store_id`를 외래 키로 참조)

### **3. 데이터 관계**

- `saving_store`와 `saving_item`은 `store_id`를 통해 연결됩니다. 

- `saving_store`의 `store_id`는 `saving_item`에서 외래 키로 사용됩니다.

### **4. 구현 과정**

- **테이블 생성**: 새로운 `saving_store`와 `saving_item` 테이블을 생성합니다.
- **데이터 이관**: 기존 `thrift_store` 테이블에서 데이터를 적절하게 추출하여 새로운 테이블로 이관합니다.
- **데이터베이스 스키마 업데이트**: 외래 키 관계와 새로운 필드를 데이터베이스 스키마에 추가합니다.
- **애플리케이션 코드 수정**: 데이터베이스 변경에 맞춰 애플리케이션의 데이터 접근 코드를 수정합니다.