### PR TITLE
[Feat/#40] 할인소식 게시판 조회 기능 변경 및 검색 기능 구현

### DIFF
--- a/src/main/java/zzandori/zzanmoa/bargainboard/controller/BargainBoardController.java
+++ b/src/main/java/zzandori/zzanmoa/bargainboard/controller/BargainBoardController.java
@@ -3,12 +3,14 @@ package zzandori.zzanmoa.bargainboard.controller;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import zzandori.zzanmoa.bargainboard.dto.BargainResponseDTO;
 import zzandori.zzanmoa.bargainboard.dto.DistrictResponseDTO;
+import zzandori.zzanmoa.bargainboard.dto.EventNullErrorDTO;
 import zzandori.zzanmoa.bargainboard.dto.PaginatedResponseDTO;
 import zzandori.zzanmoa.bargainboard.service.BargainBoardService;
 import zzandori.zzanmoa.bargainboard.service.DataSettingService;
@@ -24,8 +26,10 @@ public class BargainBoardController {
     private final DataSettingService dataSettingService;
 
     @GetMapping("/")
-    public PaginatedResponseDTO<BargainResponseDTO> getBargainBoard(@RequestParam(required = false) String eventId, @RequestParam(required = false) Integer districtId, @RequestParam(defaultValue = "0") int page) {
-        return bargainBoardService.getBargainBoard(eventId, districtId, page);
+    public ResponseEntity<?> getBargainBoard(@RequestParam(required = false) Integer eventId, @RequestParam(required = false) Integer districtId, @RequestParam(required = false) String keyword, @RequestParam(defaultValue = "0") int page) {
+
+        PaginatedResponseDTO<BargainResponseDTO> response = bargainBoardService.getBargainBoard(eventId, districtId, page, keyword);
+        return ResponseEntity.ok(response);
     }
 
     @GetMapping("/get/district")

--- a/src/main/java/zzandori/zzanmoa/bargainboard/controller/BargainBoardController.java
+++ b/src/main/java/zzandori/zzanmoa/bargainboard/controller/BargainBoardController.java
@@ -27,9 +27,15 @@ public class BargainBoardController {
 
     @GetMapping("/")
     public ResponseEntity<?> getBargainBoard(@RequestParam(required = false) Integer eventId, @RequestParam(required = false) Integer districtId, @RequestParam(required = false) String keyword, @RequestParam(defaultValue = "0") int page) {
-
-        PaginatedResponseDTO<BargainResponseDTO> response = bargainBoardService.getBargainBoard(eventId, districtId, page, keyword);
-        return ResponseEntity.ok(response);
+        if (eventId == null) {
+            return ResponseEntity.badRequest().body(new EventNullErrorDTO("이벤트 ID는 필수입니다."));
+        }
+        try {
+            PaginatedResponseDTO<BargainResponseDTO> response = bargainBoardService.getBargainBoard(eventId, districtId, page, keyword);
+            return ResponseEntity.ok(response);
+        } catch (Exception e) {
+            return ResponseEntity.internalServerError().body(new EventNullErrorDTO("할인 게시판 검색 중 오류 발생: " + e.getMessage()));
+        }
     }
 
     @GetMapping("/get/district")

--- a/src/main/java/zzandori/zzanmoa/bargainboard/dto/EventNullErrorDTO.java
+++ b/src/main/java/zzandori/zzanmoa/bargainboard/dto/EventNullErrorDTO.java
@@ -1,0 +1,16 @@
+package zzandori.zzanmoa.bargainboard.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Builder
+@ToString
+public class EventNullErrorDTO {
+    private String error;
+}

--- a/src/main/java/zzandori/zzanmoa/bargainboard/entity/BargainBoard.java
+++ b/src/main/java/zzandori/zzanmoa/bargainboard/entity/BargainBoard.java
@@ -2,8 +2,6 @@ package zzandori.zzanmoa.bargainboard.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -34,7 +32,8 @@ public class BargainBoard {
     @JoinColumn(name = "district_id")
     private District district;
 
-    @Enumerated(EnumType.STRING)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "event_id")
     private Event event;
 
     @Column(name = "title", columnDefinition = "TEXT")

--- a/src/main/java/zzandori/zzanmoa/bargainboard/entity/Event.java
+++ b/src/main/java/zzandori/zzanmoa/bargainboard/entity/Event.java
@@ -1,33 +1,33 @@
 package zzandori.zzanmoa.bargainboard.entity;
 
-public enum Event {
-    DISCOUNT_SALE(1, "할인행사"),
-    DIRECT_TRADE(2, "직거래 마켓"),
-    LIVING_COST(3, "물가 정보");
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
 
-    private final int id;
-    private final String description;
+@Entity
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+@Table(name = "event")
+public class Event {
 
-    Event(int id, String description) {
-        this.id = id;
-        this.description = description;
-    }
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
 
-    public int getId() {
-        return id;
-    }
+    @Column(name = "event_id")
+    private Integer eventId;
 
-    public String getDescription() {
-        return description;
-    }
-
-    public static Event getById(int id) {
-        for (Event event : values()) {
-            if (event.getId() == id) {
-                return event;
-            }
-        }
-        throw new IllegalArgumentException("No matching event for id: " + id);
-    }
+    @Column(name = "event_name")
+    private String eventName;
 }
-

--- a/src/main/java/zzandori/zzanmoa/bargainboard/repository/BargainBoardRepository.java
+++ b/src/main/java/zzandori/zzanmoa/bargainboard/repository/BargainBoardRepository.java
@@ -12,6 +12,10 @@ public interface BargainBoardRepository extends JpaRepository<BargainBoard, Long
     Page<BargainBoard> findByEventId(Integer eventId, Pageable pageable);
     Page<BargainBoard> findByEventIdAndDistrictId(Integer eventId, Integer districtId, Pageable pageable);
 
+    @Query("SELECT b FROM BargainBoard b WHERE " +
+        "(b.event.id = :eventId AND (b.district.id = :districtId OR :districtId IS NULL) AND " +
+        "(b.title LIKE %:keyword% OR b.content LIKE %:keyword%))")
+    Page<BargainBoard> findByEventIdAndDistrictIdAndKeyword(Integer eventId, Integer districtId, String keyword, Pageable pageable);
 
     @Query("SELECT count(b) FROM BargainBoard b WHERE b.createdAt >= :startDate")
     int countRecentNews(LocalDate startDate);

--- a/src/main/java/zzandori/zzanmoa/bargainboard/repository/BargainBoardRepository.java
+++ b/src/main/java/zzandori/zzanmoa/bargainboard/repository/BargainBoardRepository.java
@@ -7,15 +7,11 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import zzandori.zzanmoa.bargainboard.entity.BargainBoard;
-import zzandori.zzanmoa.bargainboard.entity.District;
-import zzandori.zzanmoa.bargainboard.entity.Event;
 
 public interface BargainBoardRepository extends JpaRepository<BargainBoard, Long> {
-    Page<BargainBoard> findByEvent(Event event, Pageable pageable);
-    Page<BargainBoard> findByDistrictId(Integer districtId, Pageable pageable);
-    Page<BargainBoard> findByEventAndDistrictId(Event event, Integer districtId, Pageable pageable);
+    Page<BargainBoard> findByEventId(Integer eventId, Pageable pageable);
+    Page<BargainBoard> findByEventIdAndDistrictId(Integer eventId, Integer districtId, Pageable pageable);
 
-    Page<BargainBoard> findAll(Pageable pageable);
 
     @Query("SELECT count(b) FROM BargainBoard b WHERE b.createdAt >= :startDate")
     int countRecentNews(LocalDate startDate);

--- a/src/main/java/zzandori/zzanmoa/bargainboard/repository/EventRepository.java
+++ b/src/main/java/zzandori/zzanmoa/bargainboard/repository/EventRepository.java
@@ -1,0 +1,9 @@
+package zzandori.zzanmoa.bargainboard.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import zzandori.zzanmoa.bargainboard.entity.Event;
+
+public interface EventRepository extends JpaRepository<Event, Long> {
+
+    Event findByEventId(Integer eventId);
+}

--- a/src/main/java/zzandori/zzanmoa/bargainboard/service/BargainBoardService.java
+++ b/src/main/java/zzandori/zzanmoa/bargainboard/service/BargainBoardService.java
@@ -14,7 +14,6 @@ import zzandori.zzanmoa.bargainboard.dto.DistrictResponseDTO;
 import zzandori.zzanmoa.bargainboard.dto.PaginatedResponseDTO;
 import zzandori.zzanmoa.bargainboard.entity.BargainBoard;
 import zzandori.zzanmoa.bargainboard.entity.District;
-import zzandori.zzanmoa.bargainboard.entity.Event;
 import zzandori.zzanmoa.bargainboard.repository.BargainBoardRepository;
 import zzandori.zzanmoa.bargainboard.repository.DistrictRepository;
 
@@ -30,39 +29,41 @@ public class BargainBoardService {
         return mapDistrictsToDTOs(districtList);
     }
 
-    public PaginatedResponseDTO<BargainResponseDTO> getBargainBoard(String eventId, Integer districtId,
-        int page) {
-        Page<BargainBoard> bargainBoards = fetchBargainBoards(eventId, districtId, page);
+    public PaginatedResponseDTO<BargainResponseDTO> getBargainBoard(Integer eventId, Integer districtId, int page, String keyword) {
+        Page<BargainBoard> bargainBoards;
+
+        if(keyword != null && !keyword.isEmpty()){
+            bargainBoards = searchBargainBoards(eventId, districtId, page, keyword);
+        }
+        else{
+            bargainBoards = fetchBargainBoards(eventId, districtId, page);
+        }
+
         int recentNewsCount = getRecentNewsCount();
         return buildPaginatedResponse(bargainBoards, recentNewsCount);
     }
 
-
-    private Page<BargainBoard> fetchBargainBoards(String eventId, Integer districtId, int page) {
+    private Page<BargainBoard> searchBargainBoards(Integer eventId, Integer districtId, int page, String keyword){
         Pageable pageable = PageRequest.of(page, 9);
 
-        Event event = (eventId != null) ? mapEventIdToEvent(eventId) : null;
-        if (event == null && districtId == null) {
-            return bargainBoardRepository.findAll(pageable);
-        } else if (event == null) {
-            return bargainBoardRepository.findByDistrictId(districtId, pageable);
-        } else if (districtId == null) {
-            return bargainBoardRepository.findByEvent(event, pageable);
+        if (eventId == 3) {
+            return bargainBoardRepository.findByEventIdAndDistrictIdAndKeyword(eventId, null, keyword, pageable);
         } else {
-            return bargainBoardRepository.findByEventAndDistrictId(event, districtId, pageable);
+            return bargainBoardRepository.findByEventIdAndDistrictIdAndKeyword(eventId, districtId, keyword,pageable);
         }
     }
 
-    private Event mapEventIdToEvent(String id) {
-        if ("1".equals(id)) {
-            return Event.DISCOUNT_SALE;
-        } else if ("2".equals(id)) {
-            return Event.DIRECT_TRADE;
-        } else if ("3".equals(id)) {
-            return Event.LIVING_COST;
+
+    private Page<BargainBoard> fetchBargainBoards(Integer eventId, Integer districtId, int page) {
+        Pageable pageable = PageRequest.of(page, 9);
+
+        if (eventId == 3 || districtId == null) {
+            return bargainBoardRepository.findByEventId(eventId, pageable);
+        } else {
+            return bargainBoardRepository.findByEventIdAndDistrictId(eventId, districtId, pageable);
         }
-        return null;
     }
+
 
     private int getRecentNewsCount() {
         LocalDate oneWeekAgo = LocalDate.now().minusWeeks(1);

--- a/src/main/java/zzandori/zzanmoa/bargainboard/service/BargainBoardService.java
+++ b/src/main/java/zzandori/zzanmoa/bargainboard/service/BargainBoardService.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import zzandori.zzanmoa.bargainboard.dto.BargainResponseDTO;
 import zzandori.zzanmoa.bargainboard.dto.DistrictResponseDTO;
@@ -44,7 +45,7 @@ public class BargainBoardService {
     }
 
     private Page<BargainBoard> searchBargainBoards(Integer eventId, Integer districtId, int page, String keyword){
-        Pageable pageable = PageRequest.of(page, 9);
+        Pageable pageable = PageRequest.of(page, 9, Sort.by("createdAt").descending());
 
         if (eventId == 3) {
             return bargainBoardRepository.findByEventIdAndDistrictIdAndKeyword(eventId, null, keyword, pageable);
@@ -55,7 +56,7 @@ public class BargainBoardService {
 
 
     private Page<BargainBoard> fetchBargainBoards(Integer eventId, Integer districtId, int page) {
-        Pageable pageable = PageRequest.of(page, 9);
+        Pageable pageable = PageRequest.of(page, 9, Sort.by("createdAt").descending());
 
         if (eventId == 3 || districtId == null) {
             return bargainBoardRepository.findByEventId(eventId, pageable);

--- a/src/main/java/zzandori/zzanmoa/bargainboard/service/DataSettingService.java
+++ b/src/main/java/zzandori/zzanmoa/bargainboard/service/DataSettingService.java
@@ -12,6 +12,7 @@ import zzandori.zzanmoa.bargainboard.entity.District;
 import zzandori.zzanmoa.bargainboard.entity.Event;
 import zzandori.zzanmoa.bargainboard.repository.BargainBoardRepository;
 import zzandori.zzanmoa.bargainboard.repository.DistrictRepository;
+import zzandori.zzanmoa.bargainboard.repository.EventRepository;
 import zzandori.zzanmoa.livingcost.entity.LivingCost;
 import zzandori.zzanmoa.livingcost.repository.LivingCostRepository;
 
@@ -22,6 +23,7 @@ public class DataSettingService {
     private final BargainBoardRepository bargainBoardRepository;
     private final LivingCostRepository livingCostRepository;
     private final DistrictRepository districtRepository;
+    private final EventRepository eventRepository;
 
     public void saveBargainDistrictData(){
         List<Bargain> bargains = bargainRepository.findAll();
@@ -47,7 +49,7 @@ public class DataSettingService {
 
         for (Bargain bargain : bargains) {
             District district = districtRepository.findByDistrictId(bargain.getDistrictId());
-            Event event = Event.getById(bargain.getEventId());
+            Event event = eventRepository.findByEventId(bargain.getEventId());
 
             BargainBoard bargainBoard = BargainBoard.builder()
                 .district(district)
@@ -69,7 +71,10 @@ public class DataSettingService {
 
             BargainBoard bargainBoard = BargainBoard.builder()
                 .district(null)
-                .event(Event.LIVING_COST)
+                .event(Event.builder()
+                    .eventId(3)
+                    .eventName("물가 정보")
+                    .build())
                 .title(livingCost.getTitle())
                 .content(livingCost.getContent())
                 .views(livingCost.getViews())

--- a/src/main/java/zzandori/zzanmoa/subscription/service/EmailScheduler.java
+++ b/src/main/java/zzandori/zzanmoa/subscription/service/EmailScheduler.java
@@ -23,7 +23,7 @@ public class EmailScheduler {
 
     private static final Logger logger = LoggerFactory.getLogger(EmailScheduler.class);
 
-    @Scheduled(cron = "0 0 10 * * ?", zone = "Asia/Seoul") // 매일 오전 10시에 실행
+    //@Scheduled(cron = "0 0 10 * * ?", zone = "Asia/Seoul") // 매일 오전 10시에 실행
     public void sendEmailsForPostsLastTwoMonths() {
         LocalDate twoMonthsAgo = LocalDate.now().minusMonths(3);
         List<BargainBoard> postsLastTwoMonths = bargainBoardRepository.findByCreatedAtAfter(twoMonthsAgo);


### PR DESCRIPTION
# 작업 목록

### 1. 데이터베이스 설계 변경
**이전의 `Event` 열거형(enum)을 데이터베이스 테이블로 변환했다.**
  - 이 변경은 이벤트 데이터를 동적으로 관리할 수 있게 하여, 검색과 필터링 기능을 효율적으로 지원한다.
  - `BargainBoard`의 `event` 속성이 데이터베이스의 실제 테이블과 연동될 수 있게 변경하여
  이벤트 ID에 따라 데이터를 조인하고 검색하는 기능을 개선했다.

### 2. 게시판 조회 기능 변경
**이전에는 모든 이벤트 데이터를 일괄 조회하는 기능이 있었으나
특정 이벤트(예: 물가 정보)의 경우 자치구 정보가 존재하지 않아 구현상 문제가 있었다.**
  - 따라서 모든 이벤트를 일괄 조회하는 기능을 제거하고, 각 이벤트를 개별적으로 조회하도록 로직을 변경했다.
  - 사용자가 이벤트 ID를 제공하지 않았을 경우 적절한 오류 메시지를 반환하도록 개선했다.

### 3. 게시판 검색 기능 구현
**사용자가 키워드를 입력하여 게시판의 제목이나 내용에서 해당 키워드를 포함하는 게시물을 검색할 수 있게 했다.**
`@Query` 어노테이션을 사용한 JPQL 쿼리로 구현했다.

  ```java
  @Query("SELECT b FROM BargainBoard b WHERE " +
      "(b.event.id = :eventId AND (b.district.id = :districtId OR :districtId IS NULL) AND " +
      "(b.title LIKE %:keyword% OR b.content LIKE %:keyword%))")
  Page<BargainBoard> findByEventIdAndDistrictIdAndKeyword(Integer eventId, Integer districtId, String keyword, Pageable pageable);
  ```

<br>

# 서비스 로직

### 1. 요청 처리
- **이벤트 ID 검증**
사용자로부터 입력받은 `eventId`가 없을 경우, 즉각적으로 오류 메시지를 반환한다.
- **조회 및 검색 실행**
`keyword`의 존재 여부에 따라 적절한 메소드(`searchBargainBoards` 또는 `fetchBargainBoards`)를 호출한다.

### 2. 데이터 검색 및 필터링
- **게시판 검색 (`searchBargainBoards` 메소드)**
사용자가 제공한 `keyword`를 포함하는 게시물을, `eventId`와 `districtId`를 기준으로 필터링하여 검색한다.
`eventId`가 3(`물가 정보`)일 경우, `districtId`는 고려하지 않는다.

- **게시판 조회 (`fetchBargainBoards` 메소드)**
지정된 `eventId`와 `districtId`에 따라 게시물을 필터링한다. `eventId`가 3인 경우, `districtId`는 무시된다.

### 3. 정렬 및 페이징
- 모든 조회는 게시일(`createdAt`) 기준으로 최신순으로 정렬된다. (최근 데이터에 우선순위를 두기 위해)
- `PageRequest.of` 메소드를 통해 페이징 처리가 이루어지며, 사용자에게는 페이지 정보와 함께 데이터가 제공된다.

### 4. 응답 구성
검색된 데이터는 `PaginatedResponseDTO`를 통해 클라이언트에 반환된다.
이 DTO는 페이징 처리된 결과와 함께 최근 게시물의 수를 포함하여 풍부한 정보를 제공한다.


<br>

# API 요청 시나리오

> 💡 page는 0부터 시작한다.

| event_id | event_name    |
|----------|---------------|
| 1        | 할인행사       |
| 2        | 직거래 마켓    |
| 3        | 물가 정보      |

### ✨ 게시판 조회 기능

#### 1. 이벤트 ID만 제공된 경우 (event_id = 1, 2, 3)
- **매개변수**: `eventId`, `page`
- **동작**: 지정된 `eventId`에 해당하는 모든 게시물을 해당 페이지 번호에 맞게 조회한다.
- **결과**: 지정된 이벤트 ID에 해당하는 게시물의 페이징 처리된 목록을 반환한다.

#### 2. 이벤트 ID와 지역 ID가 제공된 경우 (event_id = 1, 2)
- **매개변수**: `eventId`, `districtId`, `page`
- **동작**: 지정된 `eventId`와 `districtId`에 해당하는 게시물을 해당 페이지 번호에 맞게 조회한다.
- **결과**: 지정된 이벤트와 지역 ID에 맞는 게시물의 페이징 처리된 목록을 반환한다.

### ✨ 게시판 검색 기능

#### 1. 이벤트 ID와 키워드가 제공된 경우 (event_id = 1, 2, 3)
- **매개변수**: `eventId`, `keyword`, `page`
- **동작**: 지정된 `eventId`에 속하면서 제목이나 내용에 `keyword`를 포함하는 게시물을 해당 페이지 번호에 맞게 검색한다.
- **결과**: 검색 조건에 맞는 게시물의 페이징 처리된 목록을 반환한다.

#### 2. 이벤트 ID, 지역 ID, 키워드가 모두 제공된 경우 (event_id = 1, 2)
- **매개변수**: `eventId`, `districtId`, `keyword`, `page`
- **동작**: 지정된 `eventId`와 `districtId`에 해당하고, 제목이나 내용에 `keyword`를 포함하는 게시물을 해당 페이지 번호에 맞게 검색한다.
- **결과**: 검색 조건에 맞는 게시물의 페이징 처리된 목록을 반환한다.

<br>

### ✅ 예외 처리

#### 이벤트 ID 없이 요청된 경우

- **매개변수**: `districtId`, `keyword`, `page` (이벤트 ID 제외)
- **동작**: 이벤트 ID가 필수적이므로, 사용자에게 "이벤트 ID는 필수입니다."라는 오류 메시지와 함께 `BadRequest` 응답을 반환한다.

```json
{
    "status": "이벤트 ID는 필수입니다."
}
```

#### 요청한 조건에 맞는 게시글이 없는 경우

```json
{
    "status": "조회된 게시글이 없습니다."
}
```

#### 서버 내부에서 예외 발생한 경우

```json
{
    "status": "할인 게시판 검색 중 오류 발생: InternalServerError"
}
```

<br>

### ✅ 요청 예시
#### 정상 요청
  ```url
  http://localhost:8080/bargain-board?eventId=1&districtId=5&keyword=홈페이지&page=0
  ```
#### 오류 요청 (이벤트 ID 누락)
  ```url
  http://localhost:8080/bargain-board?districtId=5&keyword=홈페이지&page=0
  ```