### PR TITLE
[Feat/#49] 절약가격 계산 및 순위 계산 과정 수정

### DIFF
--- a/src/main/java/zzandori/zzanmoa/comparison/dto/RankDto.java
+++ b/src/main/java/zzandori/zzanmoa/comparison/dto/RankDto.java
@@ -20,4 +20,8 @@ public class RankDto {
         this.savingList = savingList;
         this.totalSaving = totalSaving;
     }
+
+    public void setRank(int rank) {
+        this.rank = rank;
+    }
 }

--- a/src/main/java/zzandori/zzanmoa/comparison/service/ComparisonService.java
+++ b/src/main/java/zzandori/zzanmoa/comparison/service/ComparisonService.java
@@ -52,7 +52,6 @@ public class ComparisonService {
     }
 
     private Map<String, List<Market>> loadMarketData(ComparisonRequestDto request) {
-        List<Item> items = itemService.getItemsByItemNames(request.getItemNames());
         List<Market> markets = marketService.getMarketsByNames(request.getMarketNames());
         return markets.stream()
             .collect(Collectors.groupingBy(Market::getMarketName));
@@ -68,10 +67,22 @@ public class ComparisonService {
     }
 
     private List<RankDto> assignRanks(List<RankDto> rankDtos) {
-        return IntStream.range(0, rankDtos.size())
-            .mapToObj(index -> new RankDto(index + 1, rankDtos.get(index).getMarket(),
-                rankDtos.get(index).getSavingList(), rankDtos.get(index).getTotalSaving()))
-            .collect(Collectors.toList());
+        if (rankDtos.isEmpty()) {
+            return rankDtos;
+        }
+        int rank = 1;
+        int prevTotalSaving = rankDtos.get(0).getTotalSaving();
+        rankDtos.get(0).setRank(rank);
+
+        for (int i = 1; i < rankDtos.size(); i++) {
+            if (rankDtos.get(i).getTotalSaving() == prevTotalSaving) {
+                rankDtos.get(i).setRank(rank);
+            } else {
+                prevTotalSaving = rankDtos.get(i).getTotalSaving();
+                rankDtos.get(i).setRank(++rank);
+            }
+        }
+        return rankDtos;
     }
 
     private RankDto buildRankDto(String marketName, List<Market> markets, List<Item> items) {

--- a/src/main/java/zzandori/zzanmoa/comparison/service/ComparisonService.java
+++ b/src/main/java/zzandori/zzanmoa/comparison/service/ComparisonService.java
@@ -58,7 +58,8 @@ public class ComparisonService {
             .collect(Collectors.groupingBy(Market::getMarketName));
     }
 
-    private List<RankDto> createAndSortRankDtos(Map<String, List<Market>> marketGroups, ComparisonRequestDto request) {
+    private List<RankDto> createAndSortRankDtos(Map<String, List<Market>> marketGroups,
+        ComparisonRequestDto request) {
         List<Item> items = itemService.getItemsByItemNames(request.getItemNames());
         return marketGroups.entrySet().stream()
             .map(entry -> buildRankDto(entry.getKey(), entry.getValue(), items))
@@ -90,8 +91,21 @@ public class ComparisonService {
     }
 
     private SavingDto createSavingDto(Market market, Item item) {
-        int saving = (market != null) ? item.getAveragePrice() - (market != null ? market.getPrice() : 0): 0;
-        return new SavingDto(new MarketItemDto(market != null ? market.getItemId() : item.getItemId(), item.getItemName(),
-            market != null ? market.getPrice() : 0, market != null && market.getPrice() < item.getAveragePrice()), saving);
+        int saving = calculatesSaving(market, item);
+        return new SavingDto(
+            createMarketItemDto(market, item)
+            , saving);
+    }
+
+    private static MarketItemDto createMarketItemDto(Market market, Item item) {
+        return new MarketItemDto(market != null ? market.getItemId() : item.getItemId(),
+            item.getItemName(),
+            market != null ? market.getPrice() : 0,
+            market != null ? true : false);
+    }
+
+    private static int calculatesSaving(Market market, Item item) {
+        return (market != null) ? (market != null ? market.getPrice() : 0) - item.getAveragePrice()
+            : 0;
     }
 }


### PR DESCRIPTION
### 1. 절약가격 계산
기존에는 '평균가격 - 실제 판매중인 품목 가격'으로 계산되던 작업을
'실제 판매중인 품목 가격 - 평균가격'을 계산되도록 수정하였습니다.

### 2. 순위 계산
Dense Ranking 로직 적용을 적용하여
동일한 절약 가격에 대해서는 동일한 순위를 갖도록 수정하였습니다.
예) 1 - 2 - 2 - 3

### 3. 재고 없는 품목에 대한 true/false
재고 있는 품목의 sale 값을 True, 재고 없는 품목의 sale 값을 False로 분류하도록 로직을 수정하였습니다.