### PR TITLE
[Feat/#51] 전역 예외처리 모듈 추가

### DIFF
--- a/src/main/java/zzandori/zzanmoa/exception/ErrorCode.java
+++ b/src/main/java/zzandori/zzanmoa/exception/ErrorCode.java
@@ -3,7 +3,6 @@ package zzandori.zzanmoa.exception;
 import org.springframework.http.HttpStatus;
 
 public interface ErrorCode {
-    String name();
     HttpStatus getHttpStatus();
     String getMessage();
 }

--- a/src/main/java/zzandori/zzanmoa/exception/ErrorCode.java
+++ b/src/main/java/zzandori/zzanmoa/exception/ErrorCode.java
@@ -1,0 +1,9 @@
+package zzandori.zzanmoa.exception;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode {
+    String name();
+    HttpStatus getHttpStatus();
+    String getMessage();
+}

--- a/src/main/java/zzandori/zzanmoa/exception/ErrorResponse.java
+++ b/src/main/java/zzandori/zzanmoa/exception/ErrorResponse.java
@@ -1,0 +1,18 @@
+package zzandori.zzanmoa.exception;
+
+import java.time.LocalDateTime;
+import lombok.Getter;
+
+@Getter
+public class ErrorResponse {
+    private final LocalDateTime timestamp = LocalDateTime.now();
+    private final int statusCode;
+    private final String error;
+    private final String message;
+
+    public ErrorResponse(ErrorCode errorCode) {
+        this.statusCode = errorCode.getHttpStatus().value();
+        this.error = errorCode.getHttpStatus().name();
+        this.message = errorCode.getMessage();
+    }
+}

--- a/src/main/java/zzandori/zzanmoa/exception/GlobalExceptionHandler.java
+++ b/src/main/java/zzandori/zzanmoa/exception/GlobalExceptionHandler.java
@@ -1,0 +1,24 @@
+package zzandori.zzanmoa.exception;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+import zzandori.zzanmoa.test.TestException;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+    @ExceptionHandler(TestException.class)
+    protected ResponseEntity<ErrorResponse> handleTestException(TestException ex) {
+        ErrorCode errorCode = ex.getErrorCode();
+        return handleExceptionInternal(errorCode);
+    }
+
+    private ResponseEntity<ErrorResponse> handleExceptionInternal(ErrorCode errorCode) {
+        return ResponseEntity
+            .status(errorCode.getHttpStatus().value())
+            .body(new ErrorResponse(errorCode));
+    }
+
+}

--- a/src/main/java/zzandori/zzanmoa/exception/GlobalExceptionHandler.java
+++ b/src/main/java/zzandori/zzanmoa/exception/GlobalExceptionHandler.java
@@ -10,8 +10,8 @@ import zzandori.zzanmoa.test.TestException;
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler(TestException.class)
-    protected ResponseEntity<ErrorResponse> handleTestException(TestException ex) {
-        ErrorCode errorCode = ex.getErrorCode();
+    protected ResponseEntity<ErrorResponse> handleTestException(TestException exception) {
+        ErrorCode errorCode = exception.getErrorCode();
         return handleExceptionInternal(errorCode);
     }
 

--- a/src/main/java/zzandori/zzanmoa/test/TestController.java
+++ b/src/main/java/zzandori/zzanmoa/test/TestController.java
@@ -2,6 +2,7 @@ package zzandori.zzanmoa.test;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -10,14 +11,19 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class TestController {
 
-  @GetMapping("/")
-  public String test() {
-    return "Hello, World!";
-  }
+    @GetMapping("/")
+    public String test() {
+        return "Hello, World!";
+    }
 
-  @GetMapping("/zzanmoa")
-  public String test2() {
-    return "Hello, zzandori!";
-  }
+    @GetMapping("/zzanmoa")
+    public String test2() {
+        return "Hello, zzandori!";
+    }
+
+    @GetMapping("/zzagmoa")
+    public ResponseEntity<String> test3() {
+        throw new TestException(TestErrorCode.INVALID_PARAMETER);
+    }
 
 }

--- a/src/main/java/zzandori/zzanmoa/test/TestErrorCode.java
+++ b/src/main/java/zzandori/zzanmoa/test/TestErrorCode.java
@@ -1,0 +1,17 @@
+package zzandori.zzanmoa.test;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import zzandori.zzanmoa.exception.ErrorCode;
+
+@Getter
+@RequiredArgsConstructor
+public enum TestErrorCode implements ErrorCode {
+
+    INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "우리는 짱모아가 아니라 짠모아입니당...");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+}

--- a/src/main/java/zzandori/zzanmoa/test/TestException.java
+++ b/src/main/java/zzandori/zzanmoa/test/TestException.java
@@ -1,0 +1,13 @@
+package zzandori.zzanmoa.test;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import zzandori.zzanmoa.exception.ErrorCode;
+
+@Getter
+@RequiredArgsConstructor
+public class TestException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+}


### PR DESCRIPTION
## 전역 예외처리 모듈

- ErrorCode 인터페이스
    - 에러 유형을 정의하기 위한 인터페이스입니다.
    - 일반적으로, 사용자가 정의한 예외 클래스는 해당 ErrorCode 인터페이스를 사용하여 구성됩니다.

- ErrorResponse 클래스
    - 예외 발생 시, 클라이언트에게 반환될 응답을 포맷합니다.

- GlobalExceptionHandler 클래스
    - @RestControllerAdvice 어노테이션을 사용하여, 애플리케이션 전반에서 발생하는 예외를 캡처합니다, 클라이언트에게 예외정보를 전달합니다.
    - @ExceptionHandler 어노테이션을 사용하여, 사용자가 정의한 예외 타입이 발생하였을 때 처리할 메소드를 지정합니다.
    
## 사용자 정의 예외 클래스 작성방법

### 1. CustomErrorCode.class를 작성합니다.
```java
@Getter
@RequiredArgsConstructor
public enum CustomErrorCode implements ErrorCode {

    INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "우리는 짱모아가 아니라 짠모아입니당...");

    private final HttpStatus httpStatus;
    private final String message;

}
```

### 2. CustomException.class를 작성합니다.
```java
@Getter
@RequiredArgsConstructor
public class CustomException extends RuntimeException {

    private final ErrorCode errorCode;

}
```


### 3. GlobalExceptionHandler.class에 사용자 정의 예외 클래스를 처리하는 방법을 정의합니다.
```java
@RestControllerAdvice
public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {


    @ExceptionHandler(CustomException.class)
    protected ResponseEntity<ErrorResponse> handleTestException(CustomException exception) {
        ErrorCode errorCode = exception.getErrorCode();
        return handleExceptionInternal(errorCode);
    }

    private ResponseEntity<ErrorResponse> handleExceptionInternal(ErrorCode errorCode) {
        return ResponseEntity
            .status(errorCode.getHttpStatus().value())
            .body(new ErrorResponse(errorCode));
    }

}
```


### 4. 비즈니스 로직 내 예외를 처리합니다.
```java
@GetMapping("/zzagmoa")
public ResponseEntity<String> handleException() {
    throw new CustomException(CustomErrorCode.INVALID_PARAMETER);
}
```
