### PR TITLE
[Feat/#52] 할인소식 이메일 구독 기능 개선

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,11 +64,14 @@ repositories {
         implementation 'io.netty:netty-resolver-dns-native-macos:4.1.68.Final:osx-aarch_64'
 
 
+        // Validation
+        implementation 'org.springframework.boot:spring-boot-starter-validation'
     }
     mavenCentral()
 }
 
 dependencies {
+    implementation 'org.jetbrains:annotations:24.0.0'
     testImplementation 'org.projectlombok:lombok:1.18.22'
 }
 

--- a/src/main/java/zzandori/zzanmoa/subscription/controller/SubscriptionController.java
+++ b/src/main/java/zzandori/zzanmoa/subscription/controller/SubscriptionController.java
@@ -14,7 +14,7 @@ import zzandori.zzanmoa.subscription.dto.SubscriptionDTO;
 import zzandori.zzanmoa.subscription.dto.SubscriptionStatusDTO;
 import zzandori.zzanmoa.subscription.service.EmailScheduler;
 import zzandori.zzanmoa.subscription.service.SubscriptionService;
-import zzandori.zzanmoa.subscription.service.ValidatorService;
+import zzandori.zzanmoa.subscription.service.SubscriptionValidationService;
 
 @Tag(name = "SubscriptionController", description = "서울시 할인 소식 구독하기 기능 컨트롤러")
 @RestController
@@ -22,7 +22,7 @@ import zzandori.zzanmoa.subscription.service.ValidatorService;
 @RequestMapping("/subscription")
 public class SubscriptionController {
 
-    private final ValidatorService validatorService;
+    private final SubscriptionValidationService validatorService;
     private final SubscriptionService subscriptionService;
     private final EmailScheduler emailScheduler;
 

--- a/src/main/java/zzandori/zzanmoa/subscription/controller/SubscriptionController.java
+++ b/src/main/java/zzandori/zzanmoa/subscription/controller/SubscriptionController.java
@@ -35,8 +35,7 @@ public class SubscriptionController {
             return validatorService.processBindingResultErrors(bindingResult);
         }
 
-        SubscriptionStatusDTO status = subscriptionService.subscribe(subscriptionDto);
-        return ResponseEntity.ok(status);
+        return subscriptionService.subscribe(subscriptionDto);
     }
 
     @PostMapping("/cancel")

--- a/src/main/java/zzandori/zzanmoa/subscription/controller/SubscriptionController.java
+++ b/src/main/java/zzandori/zzanmoa/subscription/controller/SubscriptionController.java
@@ -1,7 +1,10 @@
 package zzandori.zzanmoa.subscription.controller;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -11,6 +14,7 @@ import zzandori.zzanmoa.subscription.dto.SubscriptionDTO;
 import zzandori.zzanmoa.subscription.dto.SubscriptionStatusDTO;
 import zzandori.zzanmoa.subscription.service.EmailScheduler;
 import zzandori.zzanmoa.subscription.service.SubscriptionService;
+import zzandori.zzanmoa.subscription.service.ValidatorService;
 
 @Tag(name = "SubscriptionController", description = "서울시 할인 소식 구독하기 기능 컨트롤러")
 @RestController
@@ -18,12 +22,18 @@ import zzandori.zzanmoa.subscription.service.SubscriptionService;
 @RequestMapping("/subscription")
 public class SubscriptionController {
 
+    private final ValidatorService validatorService;
     private final SubscriptionService subscriptionService;
     private final EmailScheduler emailScheduler;
 
     @PostMapping
-    public SubscriptionStatusDTO subscribe(@RequestBody SubscriptionDTO subscriptionDto) {
-        return subscriptionService.subscribe(subscriptionDto);
+    public ResponseEntity<?> subscribe(@Valid @RequestBody SubscriptionDTO subscriptionDto, BindingResult bindingResult) {
+        if (bindingResult.hasErrors()) {
+            return validatorService.processBindingResultErrors(bindingResult);
+        }
+
+        SubscriptionStatusDTO status = subscriptionService.subscribe(subscriptionDto);
+        return ResponseEntity.ok(status);
     }
 
     @GetMapping("/send-test")

--- a/src/main/java/zzandori/zzanmoa/subscription/controller/SubscriptionController.java
+++ b/src/main/java/zzandori/zzanmoa/subscription/controller/SubscriptionController.java
@@ -10,9 +10,11 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import zzandori.zzanmoa.subscription.dto.SubscriptionCancelDTO;
 import zzandori.zzanmoa.subscription.dto.SubscriptionDTO;
 import zzandori.zzanmoa.subscription.dto.SubscriptionStatusDTO;
 import zzandori.zzanmoa.subscription.service.EmailScheduler;
+import zzandori.zzanmoa.subscription.service.SubscriptionCancelService;
 import zzandori.zzanmoa.subscription.service.SubscriptionService;
 import zzandori.zzanmoa.subscription.service.SubscriptionValidationService;
 
@@ -24,6 +26,7 @@ public class SubscriptionController {
 
     private final SubscriptionValidationService validatorService;
     private final SubscriptionService subscriptionService;
+    private final SubscriptionCancelService subscriptionCancelService;
     private final EmailScheduler emailScheduler;
 
     @PostMapping
@@ -34,6 +37,15 @@ public class SubscriptionController {
 
         SubscriptionStatusDTO status = subscriptionService.subscribe(subscriptionDto);
         return ResponseEntity.ok(status);
+    }
+
+    @PostMapping("/cancel")
+    public ResponseEntity<?> cancelSubscription(@Valid @RequestBody SubscriptionCancelDTO subscriptionCancelDTO, BindingResult bindingResult) {
+        if (bindingResult.hasErrors()) {
+            return validatorService.processBindingResultErrors(bindingResult);
+        }
+
+        return subscriptionCancelService.cancelSubscription(subscriptionCancelDTO);
     }
 
     @GetMapping("/send-test")

--- a/src/main/java/zzandori/zzanmoa/subscription/controller/SubscriptionController.java
+++ b/src/main/java/zzandori/zzanmoa/subscription/controller/SubscriptionController.java
@@ -50,6 +50,6 @@ public class SubscriptionController {
 
     @GetMapping("/send-test")
     public void sendEmail(){
-        emailScheduler.sendEmailsForPostsLastTwoMonths();
+        emailScheduler.scheduleEmailTasks();
     }
 }

--- a/src/main/java/zzandori/zzanmoa/subscription/dto/SubscriptionCancelDTO.java
+++ b/src/main/java/zzandori/zzanmoa/subscription/dto/SubscriptionCancelDTO.java
@@ -1,0 +1,24 @@
+package zzandori.zzanmoa.subscription.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Builder
+@ToString
+public class SubscriptionCancelDTO {
+
+    @NotBlank(message = "이름 입력은 필수 입니다.")
+    private String name;
+
+    @NotBlank(message = "이메일 입력은 필수 입니다.")
+    @Pattern(regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+.[A-Za-z]{2,6}$", message = "이메일 형식에 맞지 않습니다.")
+    private String email;
+}

--- a/src/main/java/zzandori/zzanmoa/subscription/dto/SubscriptionDTO.java
+++ b/src/main/java/zzandori/zzanmoa/subscription/dto/SubscriptionDTO.java
@@ -13,6 +13,7 @@ import lombok.ToString;
 @Builder
 @ToString
 public class SubscriptionDTO {
+    private String name;
     private String email;
     private List<String> district;
 }

--- a/src/main/java/zzandori/zzanmoa/subscription/dto/SubscriptionDTO.java
+++ b/src/main/java/zzandori/zzanmoa/subscription/dto/SubscriptionDTO.java
@@ -1,5 +1,8 @@
 package zzandori.zzanmoa.subscription.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Pattern;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -13,7 +16,14 @@ import lombok.ToString;
 @Builder
 @ToString
 public class SubscriptionDTO {
+
+    @NotBlank(message = "이름 입력은 필수 입니다.")
     private String name;
+
+    @NotBlank(message = "이메일 입력은 필수 입니다.")
+    @Pattern(regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+.[A-Za-z]{2,6}$", message = "이메일 형식에 맞지 않습니다.")
     private String email;
+
+    @NotEmpty(message = "자치구 선택은 필수 입니다.")
     private List<String> district;
 }

--- a/src/main/java/zzandori/zzanmoa/subscription/entity/EmailHistory.java
+++ b/src/main/java/zzandori/zzanmoa/subscription/entity/EmailHistory.java
@@ -43,4 +43,8 @@ public class EmailHistory extends TimeStamp{
 
     @Column(name = "sent_at")
     private LocalDateTime sentAt;
+
+    public void setSubscription(Subscription subscription) {
+        this.subscription = subscription;
+    }
 }

--- a/src/main/java/zzandori/zzanmoa/subscription/entity/Subscription.java
+++ b/src/main/java/zzandori/zzanmoa/subscription/entity/Subscription.java
@@ -29,6 +29,9 @@ public class Subscription extends TimeStamp{
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;
 
+    @Column(name = "name")
+    private String name;
+
     @Column(name = "email")
     private String email;
 

--- a/src/main/java/zzandori/zzanmoa/subscription/repository/EmailHistoryRepository.java
+++ b/src/main/java/zzandori/zzanmoa/subscription/repository/EmailHistoryRepository.java
@@ -1,5 +1,6 @@
 package zzandori.zzanmoa.subscription.repository;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import zzandori.zzanmoa.bargainboard.entity.BargainBoard;
 import zzandori.zzanmoa.subscription.entity.EmailHistory;
@@ -8,5 +9,6 @@ import zzandori.zzanmoa.subscription.entity.Subscription;
 public interface EmailHistoryRepository extends JpaRepository<EmailHistory, Long> {
 
     boolean existsBySubscriptionAndBargainAndStatus(Subscription subscription, BargainBoard bargainBoard, String status);
+    List<EmailHistory> findBySubscription(Subscription subscription);
 
 }

--- a/src/main/java/zzandori/zzanmoa/subscription/repository/SubscriptionRepository.java
+++ b/src/main/java/zzandori/zzanmoa/subscription/repository/SubscriptionRepository.java
@@ -9,5 +9,6 @@ public interface SubscriptionRepository extends JpaRepository<Subscription, Long
 
     List<Subscription> findByDistrict(District district);
     List<Subscription> findByEmailAndName(String email, String name);
+    List<Subscription> findByEmailAndNameAndDistrict(String email, String name, District district);
 
 }

--- a/src/main/java/zzandori/zzanmoa/subscription/repository/SubscriptionRepository.java
+++ b/src/main/java/zzandori/zzanmoa/subscription/repository/SubscriptionRepository.java
@@ -8,5 +8,6 @@ import zzandori.zzanmoa.subscription.entity.Subscription;
 public interface SubscriptionRepository extends JpaRepository<Subscription, Long> {
 
     List<Subscription> findByDistrict(District district);
+    List<Subscription> findByEmailAndName(String email, String name);
 
 }

--- a/src/main/java/zzandori/zzanmoa/subscription/service/EmailScheduler.java
+++ b/src/main/java/zzandori/zzanmoa/subscription/service/EmailScheduler.java
@@ -24,7 +24,7 @@ public class EmailScheduler {
     private static final Logger logger = LoggerFactory.getLogger(EmailScheduler.class);
     private static final String SITE_URL = "https://zzanmoa.vercel.app/";
 
-    @Scheduled(cron = "0 0 12 * * ?", zone = "Asia/Seoul")
+    @Scheduled(cron = "0 0 10 * * ?", zone = "Asia/Seoul")
     public void scheduleEmailTasks() {
         LocalDate twoMonthsAgo = LocalDate.now().minusMonths(3);
         List<BargainBoard> recentPosts = findRecentPosts(twoMonthsAgo);

--- a/src/main/java/zzandori/zzanmoa/subscription/service/EmailScheduler.java
+++ b/src/main/java/zzandori/zzanmoa/subscription/service/EmailScheduler.java
@@ -1,13 +1,13 @@
 package zzandori.zzanmoa.subscription.service;
 
 import java.time.LocalDate;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
 import zzandori.zzanmoa.bargainboard.entity.BargainBoard;
 import zzandori.zzanmoa.bargainboard.repository.BargainBoardRepository;
 import zzandori.zzanmoa.subscription.entity.Subscription;
@@ -22,22 +22,28 @@ public class EmailScheduler {
     private final SubscriptionService subscriptionService;
 
     private static final Logger logger = LoggerFactory.getLogger(EmailScheduler.class);
+    private static final String SITE_URL = "https://zzanmoa.vercel.app/";
 
-    @Scheduled(cron = "0 0 10 * * ?", zone = "Asia/Seoul") // 매일 오전 10시에 실행
-    public void sendEmailsForPostsLastTwoMonths() {
+    @Scheduled(cron = "0 0 12 * * ?", zone = "Asia/Seoul")
+    public void scheduleEmailTasks() {
         LocalDate twoMonthsAgo = LocalDate.now().minusMonths(3);
-        List<BargainBoard> postsLastTwoMonths = bargainBoardRepository.findByCreatedAtAfter(twoMonthsAgo);
+        List<BargainBoard> recentPosts = findRecentPosts(twoMonthsAgo);
+        logger.info("Found " + recentPosts.size() + " posts since " + twoMonthsAgo);
+        recentPosts.forEach(this::processPostForEmailing);
+    }
 
-        logger.info(twoMonthsAgo + "이후 할인소식 찾기");
-        logger.info("해당 게시글 갯수 : " + postsLastTwoMonths.size());
+    private List<BargainBoard> findRecentPosts(LocalDate sinceDate) {
+        return bargainBoardRepository.findByCreatedAtAfter(sinceDate);
+    }
 
-        for (BargainBoard post : postsLastTwoMonths) {
-            List<Subscription> subscriptions = subscriptionRepository.findByDistrict(post.getDistrict());
-            for (Subscription sub : subscriptions) {
-                subscriptionService.sendEmail(sub.getEmail(), "내가 구독한 자치구의 할인 소식 업데이트: " + post.getTitle(), post.getContent(), sub, post);
-            }
-        }
+    private void processPostForEmailing(BargainBoard post) {
+        List<Subscription> subscriptions = subscriptionRepository.findByDistrict(post.getDistrict());
+        subscriptions.forEach(subscription -> sendEmailToUpdateSubscribers(subscription, post));
+    }
+
+    private void sendEmailToUpdateSubscribers(Subscription subscription, BargainBoard post) {
+        String emailContent = post.getContent() + "\n자세한 정보는 여기에서 확인하세요: " + SITE_URL;
+        subscriptionService.sendEmail(subscription.getEmail(), "내가 구독한 자치구의 할인 소식 업데이트: " + post.getTitle(), emailContent, subscription, post);
     }
 
 }
-

--- a/src/main/java/zzandori/zzanmoa/subscription/service/SubscriptionCancelService.java
+++ b/src/main/java/zzandori/zzanmoa/subscription/service/SubscriptionCancelService.java
@@ -18,20 +18,26 @@ public class SubscriptionCancelService {
     private final EmailHistoryRepository emailHistoryRepository;
 
     public ResponseEntity<?> cancelSubscription(SubscriptionCancelDTO subscriptionCancelDTO){
-        String email = subscriptionCancelDTO.getEmail();;
-        String name = subscriptionCancelDTO.getName();
-        List<Subscription> subscriptionList = subscriptionRepository.findByEmailAndName(email, name);
+        List<Subscription> subscriptionList = findSubscriptions(subscriptionCancelDTO);
 
         if (subscriptionList.isEmpty()) {
             return ResponseEntity.badRequest().body("해당하는 구독 정보를 찾을 수 없습니다.");
         }
 
         setNullSubscriptionInEmailHistory(subscriptionList);
+        deleteSubscriptions(subscriptionList);
 
-        subscriptionRepository.deleteAll(subscriptionList);
         return ResponseEntity.ok().body("구독이 성공적으로 취소되었습니다.");
     }
 
+    private List<Subscription> findSubscriptions(SubscriptionCancelDTO subscriptionCancelDTO){
+        return subscriptionRepository.findByEmailAndName(subscriptionCancelDTO.getEmail(),
+            subscriptionCancelDTO.getName());
+    }
+
+    private void deleteSubscriptions(List<Subscription> subscriptions) {
+        subscriptionRepository.deleteAll(subscriptions);
+    }
 
     private void setNullSubscriptionInEmailHistory(List<Subscription> subscriptions) {
         subscriptions.forEach(subscription -> {

--- a/src/main/java/zzandori/zzanmoa/subscription/service/SubscriptionCancelService.java
+++ b/src/main/java/zzandori/zzanmoa/subscription/service/SubscriptionCancelService.java
@@ -26,9 +26,20 @@ public class SubscriptionCancelService {
             return ResponseEntity.badRequest().body("해당하는 구독 정보를 찾을 수 없습니다.");
         }
 
+        setNullSubscriptionInEmailHistory(subscriptionList);
+
         subscriptionRepository.deleteAll(subscriptionList);
         return ResponseEntity.ok().body("구독이 성공적으로 취소되었습니다.");
     }
 
 
+    private void setNullSubscriptionInEmailHistory(List<Subscription> subscriptions) {
+        subscriptions.forEach(subscription -> {
+            List<EmailHistory> emailHistories = emailHistoryRepository.findBySubscription(subscription);
+            emailHistories.forEach(emailHistory -> {
+                emailHistory.setSubscription(null);
+                emailHistoryRepository.save(emailHistory);
+            });
+        });
+    }
 }

--- a/src/main/java/zzandori/zzanmoa/subscription/service/SubscriptionCancelService.java
+++ b/src/main/java/zzandori/zzanmoa/subscription/service/SubscriptionCancelService.java
@@ -1,0 +1,34 @@
+package zzandori.zzanmoa.subscription.service;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import zzandori.zzanmoa.subscription.dto.SubscriptionCancelDTO;
+import zzandori.zzanmoa.subscription.entity.EmailHistory;
+import zzandori.zzanmoa.subscription.entity.Subscription;
+import zzandori.zzanmoa.subscription.repository.EmailHistoryRepository;
+import zzandori.zzanmoa.subscription.repository.SubscriptionRepository;
+
+@Service
+@RequiredArgsConstructor
+public class SubscriptionCancelService {
+
+    private final SubscriptionRepository subscriptionRepository;
+    private final EmailHistoryRepository emailHistoryRepository;
+
+    public ResponseEntity<?> cancelSubscription(SubscriptionCancelDTO subscriptionCancelDTO){
+        String email = subscriptionCancelDTO.getEmail();;
+        String name = subscriptionCancelDTO.getName();
+        List<Subscription> subscriptionList = subscriptionRepository.findByEmailAndName(email, name);
+
+        if (subscriptionList.isEmpty()) {
+            return ResponseEntity.badRequest().body("해당하는 구독 정보를 찾을 수 없습니다.");
+        }
+
+        subscriptionRepository.deleteAll(subscriptionList);
+        return ResponseEntity.ok().body("구독이 성공적으로 취소되었습니다.");
+    }
+
+
+}

--- a/src/main/java/zzandori/zzanmoa/subscription/service/SubscriptionService.java
+++ b/src/main/java/zzandori/zzanmoa/subscription/service/SubscriptionService.java
@@ -2,7 +2,7 @@ package zzandori.zzanmoa.subscription.service;
 
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import zzandori.zzanmoa.bargainboard.entity.BargainBoard;
@@ -21,9 +21,10 @@ import org.springframework.mail.SimpleMailMessage;
 @RequiredArgsConstructor
 public class SubscriptionService {
 
-    @Autowired
-    private JavaMailSender emailSender;
+    @Value("${MAIL_USERNAME}")
+    private String MAIL_USERNAME;
 
+    private final JavaMailSender emailSender;
     private final DistrictRepository districtRepository;
     private final SubscriptionRepository subscriptionRepository;
     private final EmailHistoryRepository emailHistoryRepository;
@@ -33,7 +34,7 @@ public class SubscriptionService {
         boolean allSavedSuccessfully = true;
 
         for (String districtName : subscriptionDto.getDistrict()) {
-            if (!createSubscription(districtName, subscriptionDto.getEmail())) {
+            if (!createSubscription(districtName, subscriptionDto.getName(),subscriptionDto.getEmail())) {
                 allSavedSuccessfully = false;
             }
         }
@@ -43,10 +44,11 @@ public class SubscriptionService {
             .build();
     }
 
-    private boolean createSubscription(String districtName, String email) {
+    private boolean createSubscription(String districtName, String name, String email) {
         try {
             District district = districtRepository.findByDistrictName(districtName);
             Subscription subscription = Subscription.builder()
+                .name(name)
                 .email(email)
                 .district(district)
                 .build();
@@ -66,7 +68,7 @@ public class SubscriptionService {
 
     private void prepareAndSendEmail(String to, String subject, String text, Subscription subscription, BargainBoard bargainBoard) {
         SimpleMailMessage message = new SimpleMailMessage();
-        message.setFrom("zzanmoa@gmail.com");
+        message.setFrom(MAIL_USERNAME + "@gmail.com");
         message.setTo(to);
         message.setSubject(subject);
         message.setText(text);

--- a/src/main/java/zzandori/zzanmoa/subscription/service/SubscriptionValidationService.java
+++ b/src/main/java/zzandori/zzanmoa/subscription/service/SubscriptionValidationService.java
@@ -10,7 +10,7 @@ import org.springframework.validation.BindingResult;
 
 @Service
 @RequiredArgsConstructor
-public class ValidatorService {
+public class SubscriptionValidationService {
 
     public ResponseEntity<?> processBindingResultErrors(BindingResult bindingResult){
         String errorMessages = bindingResult.getAllErrors()
@@ -19,5 +19,6 @@ public class ValidatorService {
             .collect(Collectors.joining(", "));
         return new ResponseEntity<>(errorMessages, HttpStatus.BAD_REQUEST);
     }
+
 
 }

--- a/src/main/java/zzandori/zzanmoa/subscription/service/ValidatorService.java
+++ b/src/main/java/zzandori/zzanmoa/subscription/service/ValidatorService.java
@@ -1,0 +1,23 @@
+package zzandori.zzanmoa.subscription.service;
+
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.support.DefaultMessageSourceResolvable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.validation.BindingResult;
+
+@Service
+@RequiredArgsConstructor
+public class ValidatorService {
+
+    public ResponseEntity<?> processBindingResultErrors(BindingResult bindingResult){
+        String errorMessages = bindingResult.getAllErrors()
+            .stream()
+            .map(DefaultMessageSourceResolvable::getDefaultMessage)
+            .collect(Collectors.joining(", "));
+        return new ResponseEntity<>(errorMessages, HttpStatus.BAD_REQUEST);
+    }
+
+}


### PR DESCRIPTION
# ✨ 구독하기 기능

이메일 주소 수집에 개인 정보 보호의 중요성을 고려하여 사용자의 동의를 받기로 결정했으며
최소한의 정보인 이메일만을 사용자로부터 수집하기로 했다.

## 요청 예시
  ```url
  http://localhost:8080/subscription
  ```

```json
{
    "email": "XXXXXXX@gmail.com",
    "district": ["양천구", "마포구", "서대문구", "달서구"]
}
```

- subscription 테이블
    - id
    - name
    - email
    - district_id
    - created_at

<br>


## 📌 구독하기 요청 시 유효성 검사

Bean Validation API 활용

```java
public class SubscriptionDTO {

    @NotBlank(message = "이메일 입력은 필수 입니다.")
    @Pattern(regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+.[A-Za-z]{2,6}$", message = "이메일 형식에 맞지 않습니다.")
    private String email;

    @NotEmpty(message = "자치구 선택은 필수 입니다.")
    private List<String> district;
}
```

유효성 검사 대상인 요청DTO에 `@Valid`를 사용하면 자동으로 검증된다.

```java
@PostMapping
public ResponseEntity<?> subscribe(@Valid @RequestBody SubscriptionDTO subscriptionDto, BindingResult bindingResult) {}
```

<br>

## 📌 중복 구독 처리 로직

1. **중복 확인**:
    - 사용자가 제출한 구독 정보(이름, 이메일, 자치구)가 이미 데이터베이스에 완전히 일치하는 형태로 존재하는 경우, 이는 중복된 구독으로 간주한다. 즉, 이 사용자는 이미 해당 자치구에 대해 구독을 진행한 상태이다. 이 경우에는 데이터베이스에 새로운 정보를 저장할 필요가 없다.
2. **새로운 구독 처리**:
    - 사용자의 구독 정보 중에서 자치구가 현재 저장된 정보와 다른 경우, 이는 새로운 구독으로 간주하여 데이터베이스에 저장해야 한다. 이는 사용자가 다양한 자치구에 대해 관심을 가질 수 있음을 반영하는 것이다.

따라서 예외 처리가 필요하다.

<br>

# ✨ 구독 취소 기능

## 요청 예시
  ```url
  http://localhost:8080/subscription/cancel
  ```

```json
{
    "email": "XXXXXXX@gmail.com"
}
```

**1. 구독 취소 요청 유효성 검사**
   요청 DTO가 NULL인지 검사한다.

**2. 구독 검색**
    데이터베이스에서 해당 이메일과 이름에 맞는 구독 리스트를 조회한다.
    
 **3. 구독 존재 여부 검사**
    조회된 구독 리스트가 비어있다면, 적절한 오류 메시지와 함께 요청이 실패했음을 알리는 응답을 반환한다.
    
**4. 이메일 기록 업데이트**
    해당 구독과 관련된 모든 이메일 기록에서 구독 정보를 제거(즉, null로 설정)한다.
    email_history 테이블에서 `subscription_id = null` 설정
    
**5. 구독 일괄 삭제**
    검색된 구독 리스트를 데이터베이스에서 삭제한다.
    
**6. 성공 응답 반환**
    모든 처리가 성공적으로 완료되면, 사용자에게 구독 취소 성공 메시지를 포함한 응답을 반환한다.

<br>

# 🚨 예외 처리
이메일 구독 기능 예외처리 : #60 