### PR TITLE
[Feat/#61] 구독 요청시 예외 처리 개선

### DIFF
--- a/src/main/java/zzandori/zzanmoa/exception/subscription/DistrictDuplicatedErrorResponse.java
+++ b/src/main/java/zzandori/zzanmoa/exception/subscription/DistrictDuplicatedErrorResponse.java
@@ -1,14 +1,15 @@
 package zzandori.zzanmoa.exception.subscription;
 
+import java.util.List;
 import lombok.Getter;
 import zzandori.zzanmoa.exception.ErrorCode;
 import zzandori.zzanmoa.exception.ErrorResponse;
 
 @Getter
 public class DistrictDuplicatedErrorResponse extends ErrorResponse {
-    private final String district;
+    private final List<String> district;
 
-    public DistrictDuplicatedErrorResponse(ErrorCode errorCode, String district) {
+    public DistrictDuplicatedErrorResponse(ErrorCode errorCode, List<String> district) {
         super(errorCode);
         this.district = district;
     }

--- a/src/main/java/zzandori/zzanmoa/exception/subscription/DistrictForSubscriptionAppException.java
+++ b/src/main/java/zzandori/zzanmoa/exception/subscription/DistrictForSubscriptionAppException.java
@@ -1,5 +1,6 @@
 package zzandori.zzanmoa.exception.subscription;
 
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -7,5 +8,5 @@ import lombok.Getter;
 @Getter
 public class DistrictForSubscriptionAppException extends RuntimeException{
     private final SubscriptionErrorCode errorCode;
-    private final String districtName;
+    private final List<String> districtName;
 }


### PR DESCRIPTION
# 🚑 기존 코드의 문제점

### **1. 단일 예외 처리**

여러 자치구에 대해 구독 요청을 받을 때, 첫 번째 발생하는 예외만 사용자에게 응답으로 전송했다.

즉, 여러 자치구에 대해 중복 구독이 발생하거나 존재하지 않는 자치구가 있을 때

첫 번째 예외만 처리하고 나머지 예외는 무시되었다.

### 2. 부분 저장 문제

일부 자치구에 대해 중복 구독이 발생해도 다른 자치구에 대한 구독은 계속 진행되었다.

사용자 입장에서는 모든 자치구에 대해 구독이 성공하거나, 구독 요청이 완전히 실패해야 일관된 처리가 이루어져야 한다.

### 3. 구독 저장 실패 처리

구독 저장에 실패할 경우 발생하는 예외를 적절히 처리하지 않았다.

모든 구독 요청이 정상적으로 처리되지 않으면 사용자에게 명확한 피드백을 제공해야 한다.

<br>

# ♻️ 리팩토링 후의 변경 사항

### 1. 모든 예외 수집

모든 자치구에 대해 중복 구독 및 존재 여부를 먼저 확인한 후, 중복 구독된 자치구 목록을 수집한다.

만약 중복 구독된 자치구가 있다면, `DistrictForSubscriptionAppException` 예외를 던져서 사용자에게 중복 구독된 자치구 목록을 응답한다. 또한 존재하지 않는 자치구에 대해서도 목록을 응답한다.

- 이미 구독한 내역이 존재하는 경우
    
    ```json
    {
        "timestamp": "2024-05-14T13:13:59.282337",
        "statusCode": 409,
        "error": "SUBSCRIPTION_DUPLICATED",
        "message": "이미 구독한 내역이 존재합니다.",
        "district": [
            "도봉구",
            "마포구"
        ]
    }
    ```
    
- 존재하지 않는 자치구인 경우
    
    ```json
    {
        "timestamp": "2024-05-14T13:13:27.258912",
        "statusCode": 404,
        "error": "DISTRICT_NOT_FOUND",
        "message": "존재하지 않는 자치구 입니다.",
        "district": [
            "달서구",
            "중라구"
        ]
    }
    ```
    

### 2. 전체 예외 처리

모든 자치구에 대해 중복 구독 및 존재 여부를 확인한 후에만 구독을 저장하도록 했다.

중복 구독이 발생하거나 존재하지 않는 자치구가 있는 경우, 구독 저장을 시도하지 않고 예외를 처리한다.

### 3. **구독 저장 실패 처리**

구독 저장 과정에서 예외가 발생하면 이를 수집하여 사용자에게 응답한다. 이로 인해 사용자는 구독 요청에 대한 상세한 피드백을 받을 수 있다.