### PR TITLE
[Feat/#63] 구독 요청시 이름 필드 삭제

### DIFF
--- a/src/main/java/zzandori/zzanmoa/subscription/dto/SubscriptionCancelDTO.java
+++ b/src/main/java/zzandori/zzanmoa/subscription/dto/SubscriptionCancelDTO.java
@@ -15,9 +15,6 @@ import lombok.ToString;
 @ToString
 public class SubscriptionCancelDTO {
 
-    @NotBlank(message = "NAME_IS_EMPTY")
-    private String name;
-
     @NotBlank(message = "EMAIL_IS_EMPTY")
     @Pattern(regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+.[A-Za-z]{2,6}$", message = "EMAIL_FORMAT_FAILED")
     private String email;

--- a/src/main/java/zzandori/zzanmoa/subscription/dto/SubscriptionDTO.java
+++ b/src/main/java/zzandori/zzanmoa/subscription/dto/SubscriptionDTO.java
@@ -17,9 +17,6 @@ import lombok.ToString;
 @ToString
 public class SubscriptionDTO {
 
-    @NotBlank(message = "NAME_IS_EMPTY")
-    private String name;
-
     @NotBlank(message = "EMAIL_IS_EMPTY")
     @Pattern(regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+.[A-Za-z]{2,6}$", message = "EMAIL_FORMAT_FAILED")
     private String email;

--- a/src/main/java/zzandori/zzanmoa/subscription/entity/Subscription.java
+++ b/src/main/java/zzandori/zzanmoa/subscription/entity/Subscription.java
@@ -29,9 +29,6 @@ public class Subscription extends TimeStamp{
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;
 
-    @Column(name = "name")
-    private String name;
-
     @Column(name = "email")
     private String email;
 

--- a/src/main/java/zzandori/zzanmoa/subscription/repository/SubscriptionRepository.java
+++ b/src/main/java/zzandori/zzanmoa/subscription/repository/SubscriptionRepository.java
@@ -8,7 +8,7 @@ import zzandori.zzanmoa.subscription.entity.Subscription;
 public interface SubscriptionRepository extends JpaRepository<Subscription, Long> {
 
     List<Subscription> findByDistrict(District district);
-    List<Subscription> findByEmailAndName(String email, String name);
-    List<Subscription> findByEmailAndNameAndDistrict(String email, String name, District district);
+    List<Subscription> findByEmail(String email);
+    List<Subscription> findByEmailAndDistrict(String email, District district);
 
 }

--- a/src/main/java/zzandori/zzanmoa/subscription/service/SubscriptionCancelService.java
+++ b/src/main/java/zzandori/zzanmoa/subscription/service/SubscriptionCancelService.java
@@ -40,8 +40,7 @@ public class SubscriptionCancelService {
     }
 
     private List<Subscription> findSubscriptions(SubscriptionCancelDTO subscriptionCancelDTO){
-        return subscriptionRepository.findByEmailAndName(subscriptionCancelDTO.getEmail(),
-            subscriptionCancelDTO.getName());
+        return subscriptionRepository.findByEmail(subscriptionCancelDTO.getEmail());
     }
 
     private void deleteSubscriptions(List<Subscription> subscriptions) {

--- a/src/main/java/zzandori/zzanmoa/subscription/service/SubscriptionService.java
+++ b/src/main/java/zzandori/zzanmoa/subscription/service/SubscriptionService.java
@@ -71,7 +71,7 @@ public class SubscriptionService {
                 notFoundDistricts.add(districtName);
                 continue;
             }
-            if (alreadySubscribe(subscriptionDto.getEmail(), subscriptionDto.getName(), district)) {
+            if (alreadySubscribe(subscriptionDto.getEmail(), district)) {
                 duplicatedDistricts.add(districtName);
             }
         }
@@ -81,21 +81,20 @@ public class SubscriptionService {
         for (String districtName : subscriptionDto.getDistrict()) {
             try {
                 District district = districtRepository.findByDistrictName(districtName);
-                createSubscription(subscriptionDto.getName(), subscriptionDto.getEmail(), district);
+                createSubscription(subscriptionDto.getEmail(), district);
             } catch (SubscriptionAppException e) {
                 errorMessages.add(e.getMessage());
             }
         }
     }
 
-    private boolean alreadySubscribe(String email, String name, District district) {
-        List<Subscription> subscriptions = subscriptionRepository.findByEmailAndNameAndDistrict(email, name, district);
+    private boolean alreadySubscribe(String email,District district) {
+        List<Subscription> subscriptions = subscriptionRepository.findByEmailAndDistrict(email, district);
         return !subscriptions.isEmpty();
     }
 
-    private void createSubscription(String name, String email, District district) {
+    private void createSubscription(String email, District district) {
         Subscription subscription = Subscription.builder()
-            .name(name)
             .email(email)
             .district(district)
             .build();


### PR DESCRIPTION
## 기능 수정
구독 요청시 사용자의 이름, 이메일 개인정보를 받았지만
혹시 모를 개인정보 보호 문제를 대비하기 위해 최소한의 정보인 이메일만 받도록 수정했다.

## 📌 구독하기
### 기존 요청

```json
{
    "name" : "짠돌이",
    "email": "XXXXXXX@gmail.com",
    "district": ["양천구", "마포구", "서대문구", "달서구"]
}
```

### 수정된 요청
```json
{
    "email": "XXXXXXX@gmail.com",
    "district": ["양천구", "마포구", "서대문구", "달서구"]
}
```

<br>

## 📌 구독 취소하기
### 기존 요청
```json
{
    "name" : "짠돌이",
    "email": "XXXXXXX@gmail.com"
}
```

### 수정된 요청
```json
{
    "email": "XXXXXXX@gmail.com"
}
```