### PR TITLE
[Feat/#72] 조회되지 않는 서비스 업체 삭제

### DIFF
--- a/src/main/java/zzandori/zzanmoa/marketplace/service/MarketDataMigrationService.java
+++ b/src/main/java/zzandori/zzanmoa/marketplace/service/MarketDataMigrationService.java
@@ -44,22 +44,18 @@ public class MarketDataMigrationService {
         FindPlaceResponse findPlaceResponse = googleMapApiService.requestFindPlace(market.getMarketName());
         List<Candidate> candidates = findPlaceResponse.getCandidates();
 
-        String formattedAddress = null;
-        String placeId = null;
-        Location location = null;
-
         if (!candidates.isEmpty()) {
             Candidate candidate = candidates.get(0);
-            formattedAddress = candidates.get(0).getFormatted_address();
-            placeId = candidate.getPlace_id();
-            location = fetchLocation(formattedAddress);
+            String formattedAddress = candidates.get(0).getFormatted_address();
+            String placeId = candidate.getPlace_id();
+            Location location = fetchLocation(formattedAddress);
+
+            MarketPlace marketPlace = buildMarketPlace(market, formattedAddress, location);
+            marketPlaceRepository.save(marketPlace);
+
+            MarketPlaceGoogleIds marketPlaceGoogleIds = buildMarketPlaceGoogleIds(placeId, marketPlace);
+            marketPlaceGoogleIdsRepository.save(marketPlaceGoogleIds);
         }
-
-        MarketPlace marketPlace = buildMarketPlace(market, formattedAddress, location);
-        marketPlaceRepository.save(marketPlace);
-
-        MarketPlaceGoogleIds marketPlaceGoogleIds = buildMarketPlaceGoogleIds(placeId, marketPlace);
-        marketPlaceGoogleIdsRepository.save(marketPlaceGoogleIds);
     }
 
     private Location fetchLocation(String address) {

--- a/src/main/java/zzandori/zzanmoa/savingplace/service/SavingDataMigrationService.java
+++ b/src/main/java/zzandori/zzanmoa/savingplace/service/SavingDataMigrationService.java
@@ -83,12 +83,12 @@ public class SavingDataMigrationService {
     }
 
     private void persistStoresAndItems(SavingStore savingStore) {
-        savingStoreRepository.save(savingStore);
         String placeId = getGooglePlaceId(savingStore.getAddress(), savingStore.getStoreName());
         if (placeId != null) {
+            savingStoreRepository.save(savingStore);
             savingStoreGoogleIdsRepository.save(buildSavingStoreGoogleIds(placeId, savingStore));
+            savingItemRepository.saveAll(savingStore.getItems());
         }
-        savingItemRepository.saveAll(savingStore.getItems());
     }
 
     private String getGooglePlaceId(String address, String storeName) {

--- a/src/main/java/zzandori/zzanmoa/savingplace/service/SavingDataMigrationService.java
+++ b/src/main/java/zzandori/zzanmoa/savingplace/service/SavingDataMigrationService.java
@@ -84,13 +84,16 @@ public class SavingDataMigrationService {
 
     private void persistStoresAndItems(SavingStore savingStore) {
         savingStoreRepository.save(savingStore);
-        savingStoreGoogleIdsRepository.save(buildSavingStoreGoogleIds(
-            getGooglePlaceId(savingStore.getAddress(), savingStore.getStoreName()), savingStore));
+        String placeId = getGooglePlaceId(savingStore.getAddress(), savingStore.getStoreName());
+        if (placeId != null) {
+            savingStoreGoogleIdsRepository.save(buildSavingStoreGoogleIds(placeId, savingStore));
+        }
         savingItemRepository.saveAll(savingStore.getItems());
     }
 
     private String getGooglePlaceId(String address, String storeName) {
-        FindPlaceResponse findPlaceResponse = googleMapApiService.requestFindPlace(address + " " + storeName);
+        FindPlaceResponse findPlaceResponse = googleMapApiService.requestFindPlace(
+            address + " " + storeName);
         List<Candidate> candidates = findPlaceResponse.getCandidates();
 
         if (!candidates.isEmpty()) {


### PR DESCRIPTION
## 문제상황

서울시 공공데이터에서 제공하는 [서울시 개인서비스 요금 정보 API](https://data.seoul.go.kr/dataList/OA-1169/A/1/datasetView.do;jsessionid=E357FC31615DF9EA60C411481818DA87.new_portal-svr-11)와 [서울시 생필품 농수축산물 가격 정보 API](https://data.seoul.go.kr/dataList/OA-1170/S/1/datasetView.do) 데이터 중 조회가 되지 않거나, 폐업한 업체가 존재한다.

## 문제 해결

짠모아에서는 자체적으로 필터링하여 조회되는 업체에 대해서만 정보를 제공하고자 한다.
[Google Place API](https://developers.google.com/maps/documentation/places/web-service/overview?hl=ko)에서 조회되지 않는 업소의 경우 Candidate 리스트가 반환되지 않는 점을 이용하여, 이러한 경우 자체 데이터베이스에 저장을 하지 않도록 로직을 수정하였다.